### PR TITLE
Remove abort-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native JavaScript [navigation](https://html.spec.whatwg.org/multipage/nav-histor
 
  <details><summary>Test Coverage</summary>
 
- ![Web Platform Tests 140/277](https://img.shields.io/badge/Web%20Platform%20Tests-140%2F277-brightgreen) ![92.8%25 lines covered](https://img.shields.io/badge/lines-92.8%25-brightgreen) ![92.8%25 statements covered](https://img.shields.io/badge/statements-92.8%25-brightgreen) ![83.33%25 functions covered](https://img.shields.io/badge/functions-83.33%25-brightgreen) ![82.97%25 branches covered](https://img.shields.io/badge/branches-82.97%25-brightgreen) 
+ 
 
 </details>
 

--- a/example/polyfill-rollup.js
+++ b/example/polyfill-rollup.js
@@ -450,15 +450,10 @@ function ok$1(value) {
 
 const GlobalAbortController = typeof AbortController !== "undefined" ? AbortController : undefined;
 
-// import ImportedAbortController from "abort-controller";
-// async function importAbortController() {
-//     const { default: AbortController } = await import("abort-controller");
-//     return AbortController;
-// }
 if (!GlobalAbortController) {
     throw new Error("AbortController expected to be available or polyfilled");
 }
-const AbortController$1 = GlobalAbortController; // await importAbortController();
+const AbortController$1 = GlobalAbortController;
 
 function isPromise(value) {
     return (like(value) &&

--- a/example/rollup.js
+++ b/example/rollup.js
@@ -446,15 +446,10 @@ function ok$1(value) {
 
 const GlobalAbortController = typeof AbortController !== "undefined" ? AbortController : undefined;
 
-// import ImportedAbortController from "abort-controller";
-// async function importAbortController() {
-//     const { default: AbortController } = await import("abort-controller");
-//     return AbortController;
-// }
 if (!GlobalAbortController) {
     throw new Error("AbortController expected to be available or polyfilled");
 }
-const AbortController$1 = GlobalAbortController; // await importAbortController();
+const AbortController$1 = GlobalAbortController;
 
 function isPromise(value) {
     return (like(value) &&

--- a/example/routes-rollup.js
+++ b/example/routes-rollup.js
@@ -2388,15 +2388,10 @@ function ok(value) {
 
 const GlobalAbortController = typeof AbortController !== "undefined" ? AbortController : undefined;
 
-// import ImportedAbortController from "abort-controller";
-// async function importAbortController() {
-//     const { default: AbortController } = await import("abort-controller");
-//     return AbortController;
-// }
 if (!GlobalAbortController) {
     throw new Error("AbortController expected to be available or polyfilled");
 }
-const AbortController$1 = GlobalAbortController; // await importAbortController();
+const AbortController$1 = GlobalAbortController;
 
 const Rollback = Symbol.for("@virtualstate/navigation/rollback");
 const Unset = Symbol.for("@virtualstate/navigation/unset");

--- a/import-map-deno.json
+++ b/import-map-deno.json
@@ -30,7 +30,6 @@
     "iterable": "https://cdn.skypack.dev/iterable@6.0.1-beta.5",
     "https://cdn.skypack.dev/-/iterable@v5.7.0-CNtyuMJo9f2zFu6CuB1D/dist=es2019,mode=imports/optimized/iterable.js": "https://cdn.skypack.dev/iterable@6.0.1-beta.5",
     "uuid": "./src/util/deno-uuid.ts",
-    "abort-controller": "https://cdn.skypack.dev/abort-controller",
     "deno:std/uuid/mod": "https://deno.land/std@0.113.0/uuid/mod.ts",
     "deno:std/uuid/v4": "https://deno.land/std@0.113.0/uuid/v4.ts",
     "deno:deno_dom/deno-dom-wasm.ts": "https://deno.land/x/deno_dom/deno-dom-wasm.ts",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
   "dependencies": {
     "@ungap/structured-clone": "^1.0.2",
     "@virtualstate/composite-key": "^1.0.0",
-    "abort-controller": "^3.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/import-abort-controller.ts
+++ b/src/import-abort-controller.ts
@@ -1,13 +1,7 @@
 import { GlobalAbortController } from "./global-abort-controller";
-// import ImportedAbortController from "abort-controller";
-
-// async function importAbortController() {
-//     const { default: AbortController } = await import("abort-controller");
-//     return AbortController;
-// }
 
 if (!GlobalAbortController) {
   throw new Error("AbortController expected to be available or polyfilled");
 }
 
-export const AbortController = GlobalAbortController; // await importAbortController();
+export const AbortController = GlobalAbortController;

--- a/src/tests/dependencies-input.ts
+++ b/src/tests/dependencies-input.ts
@@ -23,7 +23,6 @@ export const DefaultDependencies = [
   "dom-lite",
   "iterable",
   "uuid",
-  "abort-controller",
   "urlpattern-polyfill",
   "@ungap/structured-clone",
   "@ungap/structured-clone/json"


### PR DESCRIPTION
`abort-controller` is a polyfill for the [AbortController API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).

It looks like since there is good browser support for this API, the polyfill is optional and was removed from all code paths.

This PR removes the dependency and the unused code paths and instrumentation.