### PR TITLE
Update matchesAncestors to search light-dom ancestors

### DIFF
--- a/example/polyfill-rollup.js
+++ b/example/polyfill-rollup.js
@@ -2678,7 +2678,7 @@ function matchesAncestor(givenElement, selector) {
             ok(element);
             return element;
         }
-        element = element.parentElement;
+        element = element.parentElement ?? element.getRootNode()?.host;
     }
     return undefined;
     function getDefaultElement() {

--- a/example/rollup.js
+++ b/example/rollup.js
@@ -2686,7 +2686,7 @@ function matchesAncestor(givenElement, selector) {
             ok(element);
             return element;
         }
-        element = element.parentElement;
+        element = element.parentElement ?? element.getRootNode()?.host;
     }
     return undefined;
     function getDefaultElement() {
@@ -2695,6 +2695,16 @@ function matchesAncestor(givenElement, selector) {
         if (givenElement.matches instanceof Function)
             return givenElement;
         return givenElement.parentElement;
+    }
+}
+
+if (typeof window !== "undefined" && window.navigation) {
+    const navigation = window.navigation;
+    assertNavigation(navigation);
+}
+function assertNavigation(value) {
+    if (!value) {
+        throw new Error("Expected Navigation");
     }
 }
 

--- a/src/get-polyfill.ts
+++ b/src/get-polyfill.ts
@@ -825,7 +825,7 @@ function matchesAncestor(givenElement: ElementPrototype | undefined, selector: s
       ok<ElementPrototype>(element);
       return element;
     }
-    element = element.parentElement;
+    element = element.parentElement ?? element.getRootNode()?.host;
   }
   return undefined;
 

--- a/src/global-window.ts
+++ b/src/global-window.ts
@@ -5,12 +5,14 @@ export interface ElementPrototype {
     new(): ElementPrototype;
     ownerDocument: unknown;
     parentElement?: ElementPrototype;
+    host?: ElementPrototype;
     matches(string: string): boolean;
     getAttribute(name: string): string;
     setAttribute(name: string, value: string): void;
     cloneNode(): ElementPrototype;
     click(): void;
     submit(): void;
+    getRootNode(): ElementPrototype | null;
 }
 
 export interface HTMLAnchorElementPrototype extends ElementPrototype {


### PR DESCRIPTION
This PR addresses https://github.com/virtualstate/navigation/issues/29 by extending `matchesAncestor` helper to search through light-dom ancestors once it has reached the bounds of a shadow-dom.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/virtualstate/x/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `yarn build`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/virtualstate/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/virtualstate/.github/blob/master/CODE_OF_CONDUCT.md)
