### PR TITLE
Fix: make navigation check more strict

### DIFF
--- a/src/apply-polyfill.ts
+++ b/src/apply-polyfill.ts
@@ -11,7 +11,7 @@ export function applyPolyfill(options: NavigationPolyfillOptions = DEFAULT_POLYF
 export function shouldApplyPolyfill(navigation = getNavigation()) {
   return (
       navigation !== globalNavigation &&
-      !globalNavigation &&
+      !Object.hasOwn(globalThis, 'navigation') &&
       typeof window !== "undefined"
   );
 }


### PR DESCRIPTION
This patch is there to ignore the pollution of Ids from HTMLElements in lightdom effecting the check if the polyfill should be applied

`<div id="navigation">` in the DOM would make shouldApplyPolyfill return false, which is non desired behavior IMO.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/virtualstate/x/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `yarn build`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/virtualstate/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/virtualstate/.github/blob/master/CODE_OF_CONDUCT.md)
